### PR TITLE
Fix crash when trying to read empty array

### DIFF
--- a/src/FirestoreDocument.php
+++ b/src/FirestoreDocument.php
@@ -192,6 +192,9 @@ class FirestoreDocument {
     {
         $results = [];
 
+        if (empty($value['arrayValue']['values'])) {
+            return [];
+        }
         foreach ($value['arrayValue']['values'] as $key => $value) {
             $results[$key] = $this->castValue($value);
         }

--- a/src/FirestoreDocument.php
+++ b/src/FirestoreDocument.php
@@ -192,11 +192,10 @@ class FirestoreDocument {
     {
         $results = [];
 
-        if (empty($value['arrayValue']['values'])) {
-            return [];
-        }
-        foreach ($value['arrayValue']['values'] as $key => $value) {
-            $results[$key] = $this->castValue($value);
+        if (isset($value['arrayValue']['values']) && is_array($value['arrayValue']['values'])) {
+            foreach ($value['arrayValue']['values'] as $key => $value) {
+                $results[$key] = $this->castValue($value);
+            }
         }
 
         return $results;


### PR DESCRIPTION
When you have an empty array in your Firestore, and you try to read that with firestore-php, your will encounter an undefined index error. This pull request fixes this by checking if the array is empty, and if so, returns the empty array instead of trying to iterate over it.