### PR TITLE
Allow storing associative arrays

### DIFF
--- a/src/Fields/FirestoreObject.php
+++ b/src/Fields/FirestoreObject.php
@@ -17,9 +17,9 @@ class FirestoreObject implements FirestoreDataTypeContract
         }
     }
 
-    public function add($data)
+    public function add($key, $value)
     {
-        array_push($this->data, $data);
+        $this->data[$key] = $value;
 
         return $this;
     }

--- a/src/FirestoreDocument.php
+++ b/src/FirestoreDocument.php
@@ -208,8 +208,8 @@ class FirestoreDocument {
     {
         if ( !$value instanceof FirestoreObject ) {
             $payload = new FirestoreObject;
-            foreach ($value as $row) {
-                $payload->add( $row );
+            foreach ($value as $key => $row) {
+                $payload->add( $key, $row );
             }
 
             $value = $payload;

--- a/src/Helpers/FirestoreHelper.php
+++ b/src/Helpers/FirestoreHelper.php
@@ -95,6 +95,12 @@ class FirestoreHelper
     {
         $type = gettype($value);
 
+        if ($type === 'array') {
+            if (array_values($value) !== $value) {
+                return 'object';
+            }
+        }
+
         if ( $type === 'object' ) {
             if ( $value instanceof FirestoreReference ) {
                 return 'reference';


### PR DESCRIPTION
This PR fixes two issues:

1. Properly treating objects as having keys and values instead of just values. Previously object's keys were lost when converting to FirestoreObject.

2. Added additional check to see if the array is associative and then treat it as an object. This allows using associative arrays instead of objects.