### PR TITLE
Increase maximum JSON decode depth

### DIFF
--- a/src/Helpers/FirestoreHelper.php
+++ b/src/Helpers/FirestoreHelper.php
@@ -20,7 +20,7 @@ class FirestoreHelper
      */
     public static function decode($value)
     {
-        return json_decode($value, true, JSON_FORCE_OBJECT);
+        return json_decode($value, true);
     }
 
     /**


### PR DESCRIPTION
The parameter `JSON_FORCE_OBJECT` was mistakenly applied to `json_decode` as the 3rd parameter (`depth`), which caused the maximum depth to be set to 16.

This caused requests with deep documents to fail to upload to Firestore. 

Removing this argument, thus restoring to the default 512, solves the issue.