### PR TITLE
Store http response code in UnhandledRequestError

### DIFF
--- a/src/Exceptions/UnhandledRequestError.php
+++ b/src/Exceptions/UnhandledRequestError.php
@@ -7,6 +7,6 @@ class UnhandledRequestError extends \Exception
     public function __construct($code, $response)
     {
         $message = 'The request failed with the error: '.$code.'.  Response: '.$response;
-        parent::__construct($message);
+        parent::__construct($message, $code);
     }
 }


### PR DESCRIPTION
This allows the user to deal with errors in a more informed way - for example, if the response code is 502 or 503, it might be a good idea to wait 15-30 seconds and try again.