### PR TITLE
Add a few tests for FirestoreDocument and fix odd behaviour of getCreatedTime

### DIFF
--- a/src/FirestoreDocument.php
+++ b/src/FirestoreDocument.php
@@ -78,6 +78,10 @@ class FirestoreDocument {
      */
     public function getCreatedTime()
     {
+        if (is_null($this->createTime)) {
+            return null;
+        }
+
         return new DateTime($this->createTime);
     }
 
@@ -86,6 +90,10 @@ class FirestoreDocument {
      */
     public function getUpdatedTime()
     {
+        if (is_null($this->updateTime)) {
+            return null;
+        }
+
         return new DateTime($this->updateTime);
     }
 

--- a/tests/FirestoreDocumentTest.php
+++ b/tests/FirestoreDocumentTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace MrShan0\PHPFirestore\Tests;
+
+use MrShan0\PHPFirestore\FirestoreDocument;
+use PHPUnit\Framework\TestCase;
+
+class FirestoreDocumentTest extends TestCase
+{
+    /** @test */
+    public function get_absolute_name_returns_name()
+    {
+        $document = new FirestoreDocument(
+            [
+                'name' => 'projects/database/(default)/documents/collection/item',
+            ]
+        );
+
+        $this->assertSame('projects/database/(default)/documents/collection/item', $document->getAbsoluteName());
+    }
+
+
+    /** @test */
+    public function get_absolute_name_returns_null_if_no_document_provided()
+    {
+        $document = new FirestoreDocument();
+
+        $this->assertNull($document->getAbsoluteName());
+    }
+
+
+    /** @test */
+    public function get_created_time_returns_created_time()
+    {
+        $document = new FirestoreDocument(
+            [
+                'name' => 'projects/database/(default)/documents/collection/item',
+                'createTime' => '2018-12-24T15:00:00.123456Z',
+                'updateTime' => '2018-12-24T16:00:00.123456Z',
+                'fields' => [
+                    'myKey' => [
+                        'stringValue' => 'my value'
+                    ]
+                ],
+            ]
+        );
+
+        $this->assertEquals(new \DateTime('2018-12-24T15:00:00.123456Z'), $document->getCreatedTime());
+    }
+
+
+    /** @test */
+    public function get_updated_time_returns_updated_time()
+    {
+        $document = new FirestoreDocument(
+            [
+                'name' => 'projects/database/(default)/documents/collection/item',
+                'createTime' => '2018-12-24T15:00:00.123456Z',
+                'updateTime' => '2018-12-24T16:00:00.123456Z',
+                'fields' => [
+                    'myKey' => [
+                        'stringValue' => 'my value'
+                    ]
+                ],
+            ]
+        );
+
+        $this->assertEquals(new \DateTime('2018-12-24T16:00:00.123456Z'), $document->getUpdatedTime());
+    }
+
+
+    /** @test */
+    public function get_created_time_returns_null_if_document_does_not_exist()
+    {
+        $document = new FirestoreDocument(
+            [
+                'name' => 'projects/database/(default)/documents/collection/item',
+            ]
+        );
+
+        $this->assertNull($document->getCreatedTime());
+    }
+
+
+    /** @test */
+    public function get_updated_time_returns_null_if_document_does_not_exist()
+    {
+        $document = new FirestoreDocument(
+            [
+                'name' => 'projects/database/(default)/documents/collection/item',
+            ]
+        );
+
+        $this->assertNull($document->getUpdatedTime());
+    }
+
+
+    /** @test */
+    public function get_name_returns_name()
+    {
+        $document = new FirestoreDocument(
+            [
+                'name' => 'projects/database/(default)/documents/collection/item',
+            ]
+        );
+
+        $this->assertSame('projects/database/(default)/documents/collection/item', $document->getName());
+    }
+
+
+    /** @test */
+    public function get_name_returns_null_if_no_document_provided()
+    {
+        $document = new FirestoreDocument();
+
+        $this->assertNull($document->getName());
+    }
+}


### PR DESCRIPTION
I wrote a few tests for FirestoreDocument, it's not complete but it's
what I had time for. In the course of testing I found that getCreatedTime
and getUpdatedTime was returning _now_ when no value was provided (such as
listing a non-existent document or creating a new document), so I changed
that as well.

Please let me know if you want me to change anything about the style, structure or something else about the tests and I will try to change them accordingly. 