### PR TITLE
Fill class @method phpdoc to avoid lint warnings using FirestoreClient

### DIFF
--- a/src/FirestoreClient.php
+++ b/src/FirestoreClient.php
@@ -9,6 +9,15 @@ use MrShan0\PHPFirestore\Authentication\FirestoreAuthentication;
 use MrShan0\PHPFirestore\Handlers\RequestErrorHandler;
 use MrShan0\PHPFirestore\Helpers\FirestoreHelper;
 
+/**
+ * @method array listDocuments($collection, array $parameters = [], array $options = [])
+ * @method FirestoreDocument getDocument($documentPath, array $parameters = [], array $options = [])
+ * @method array getBatchDocuments(array $documentsId, array $parameters = [], array $options = [])
+ * @method FirestoreDocument addDocument($collection, $payload, $documentId = null, array $parameters = [], array $options = [])
+ * @method FirestoreDocument updateDocument($documentPath, $payload, $documentExists = null, array $parameters = [], array $options = [])
+ * @method FirestoreDocument setDocument($documentPath, $payload, $documentExists = null, array $parameters = [], array $options = [])
+ * @method boolean deleteDocument($document, array $options = [])
+ */
 class FirestoreClient
 {
     /**


### PR DESCRIPTION
Currently when you use some of the FirestoreClient methods, IDE would show a lint warning because the API is written using the ```__call``` magic method.

This PR is to avoid that lint warnings, using phpdoc.