### PR TITLE
Fix "Call to undefined method" if authRequest() fails

### DIFF
--- a/src/Authentication/FirestoreAuthentication.php
+++ b/src/Authentication/FirestoreAuthentication.php
@@ -152,7 +152,7 @@ class FirestoreAuthentication
 
             return FirestoreHelper::decode((string) $this->client->getLastResponse()->getBody());
         } catch (BadResponseException $exception) {
-            $this->setLastResponse($exception->getResponse());
+            $this->client->setLastResponse($exception->getResponse());
             $this->handleError($exception);
         }
     }


### PR DESCRIPTION
Had to workaround this at my end, but a quick fix should stop others having issues in future.

Haven't written any tests because this whole library lacks tests...