### PR TITLE
Adding support for FIRESTORE_EMULATOR_HOST env variable

### DIFF
--- a/src/FirestoreClient.php
+++ b/src/FirestoreClient.php
@@ -176,10 +176,15 @@ class FirestoreClient
         return 'projects/' . self::getConfig('projectId') . '/databases/' . self::getConfig('database');
     }
 
-    public function getApiEndPoint()
-    {
-        return $this->apiRoot;
-    }
+	public function getApiEndPoint() {
+		$emulator = getenv('FIRESTORE_EMULATOR_HOST');
+
+		if ($emulator) {
+			return $emulator;
+		}
+
+		return $this->apiRoot;
+	}
 
     /**
      * @param bool $status


### PR DESCRIPTION
Checking the env var is the standard way of interfacing with the firebase emulator.